### PR TITLE
Add use-pr-linker workflow to auto-link PRs to issues

### DIFF
--- a/.github/workflows/use-pr-linker.yml
+++ b/.github/workflows/use-pr-linker.yml
@@ -1,0 +1,21 @@
+name: Auto link PR to Issues
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  call-linker:
+    uses: mosip/kattu/.github/workflows/link-pr-to-issue.yml@develop
+    secrets:
+      ACTION_PAT: ${{ secrets.ACTION_PAT }}


### PR DESCRIPTION
## Summary
Adds `use-pr-linker.yml` workflow that calls the reusable PR-to-issue linker from `mosip/kattu` (`@develop`).

## Notes
- Requires `ACTION_PAT` repository secret to be configured.
- Target branch: `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated workflow to link pull requests to related issues, improving internal issue tracking and project management processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/ida-data-seeder/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->